### PR TITLE
Add patches to enable igt-gpu-tools to be build with musl

### DIFF
--- a/x11-apps/igt-gpu-tools/i-g-t-Fix-global-symbol-loading-failure-in-resolve-function.patch
+++ b/x11-apps/igt-gpu-tools/i-g-t-Fix-global-symbol-loading-failure-in-resolve-function.patch
@@ -1,0 +1,63 @@
+diff --git lib/igt_halffloat.c lib/igt_halffloat.c
+index 08ab05fc..e5e8a5bd 100644
+--- a/lib/igt_halffloat.c
++++ b/lib/igt_halffloat.c
+@@ -24,6 +24,19 @@
+ 
+ #include <assert.h>
+ #include <math.h>
++#include <stdbool.h>
++
++#ifdef HAVE_CPUID_H
++#include <cpuid.h>
++#else
++#define __get_cpuid_max(x, y) 0
++#define __cpuid(level, a, b, c, d) a = b = c = d = 0
++#define __cpuid_count(level, count, a, b, c, d) a = b = c = d = 0
++#endif
++
++#ifndef bit_F16C
++#define bit_F16C	(1 << 29)
++#endif
+ 
+ #include "igt_halffloat.h"
+ #include "igt_x86.h"
+@@ -182,6 +195,20 @@ static void half_to_float_f16c(const uint16_t *h, float *f, unsigned int num)
+ 
+ #pragma GCC pop_options
+ 
++static bool f16c_is_supported(void)
++{
++	unsigned max = __get_cpuid_max(0, NULL);
++	unsigned eax, ebx, ecx, edx;
++
++	if (max >= 1) {
++		__cpuid(1, eax, ebx, ecx, edx);
++
++		if (ecx & bit_F16C)
++			return true;
++	}
++	return false;
++}
++
+ static void float_to_half(const float *f, uint16_t *h, unsigned int num)
+ {
+ 	for (int i = 0; i < num; i++)
+@@ -196,7 +223,7 @@ static void half_to_float(const uint16_t *h, float *f, unsigned int num)
+ 
+ static void (*resolve_float_to_half(void))(const float *f, uint16_t *h, unsigned int num)
+ {
+-	if (igt_x86_features() & F16C)
++	if (f16c_is_supported())
+ 		return float_to_half_f16c;
+ 
+ 	return float_to_half;
+@@ -207,7 +234,7 @@ void igt_float_to_half(const float *f, uint16_t *h, unsigned int num)
+ 
+ static void (*resolve_half_to_float(void))(const uint16_t *h, float *f, unsigned int num)
+ {
+-	if (igt_x86_features() & F16C)
++	if (f16c_is_supported())
+ 		return half_to_float_f16c;
+ 
+ 	return half_to_float;

--- a/x11-apps/igt-gpu-tools/musl-ioctl.patch
+++ b/x11-apps/igt-gpu-tools/musl-ioctl.patch
@@ -1,0 +1,22 @@
+diff --git a/benchmarks/gem_exec_tracer.c b/benchmarks/gem_exec_tracer.c
+index c8f4e84b..dc9cad12 100644
+--- a/benchmarks/gem_exec_tracer.c
++++ b/benchmarks/gem_exec_tracer.c
+@@ -42,7 +42,7 @@
+ #include "intel_chipset.h"
+ 
+ static int (*libc_close)(int fd);
+-static int (*libc_ioctl)(int fd, unsigned long request, void *argp);
++static int (*libc_ioctl)(int fd, int request, void *argp);
+ 
+ static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+ 
+@@ -270,7 +270,7 @@ static int is_i915(int fd)
+     DRM_IOWR(DRM_COMMAND_BASE + DRM_I915_GEM_EXECBUFFER2, struct drm_i915_gem_execbuffer2)
+ 
+ int
+-ioctl(int fd, unsigned long request, ...)
++ioctl(int fd, int request, ...)
+ {
+ 	struct trace *t, **p;
+ 	va_list args;

--- a/x11-apps/igt-gpu-tools/musl.patch
+++ b/x11-apps/igt-gpu-tools/musl.patch
@@ -1,0 +1,183 @@
+diff --git a/benchmarks/gem_syslatency.c b/benchmarks/gem_syslatency.c
+index 7671dc4..3ac9544 100644
+--- a/benchmarks/gem_syslatency.c
++++ b/benchmarks/gem_syslatency.c
+@@ -44,7 +44,11 @@
+ 
+ #include <linux/unistd.h>
+ 
+-#define sigev_notify_thread_id _sigev_un._tid
++#ifndef __GLIBC__
++#include "signal_compat.h"
++#endif
++
++#define sigev_notify_thread_id sigev_notify_function
+ 
+ static volatile int done;
+ 
+diff --git a/lib/igt_aux.c b/lib/igt_aux.c
+index 578f857..3e98cf0 100644
+--- a/lib/igt_aux.c
++++ b/lib/igt_aux.c
+@@ -31,6 +31,7 @@
+ #endif
+ #include <stdio.h>
+ #include <fcntl.h>
++#include <limits.h> // PATH_MAX
+ #include <sys/stat.h>
+ #include <sys/ioctl.h>
+ #include <string.h>
+@@ -73,6 +74,12 @@
+ #include <libgen.h>   /* for dirname() */
+ #endif
+ 
++#ifndef __GLIBC__
++#include "signal_compat.h"
++#endif
++
++//#include <asm-generic/siginfo.h>
++
+ /**
+  * SECTION:igt_aux
+  * @short_description: Auxiliary libraries and support functions
+diff --git a/lib/igt_aux.h b/lib/igt_aux.h
+index 04d2290..a0ada9e 100644
+--- a/lib/igt_aux.h
++++ b/lib/igt_aux.h
+@@ -46,7 +46,7 @@
+ #  define gettid() (pid_t)(syscall(__NR_gettid))
+ # endif
+ #endif
+-#define sigev_notify_thread_id _sigev_un._tid
++#define sigev_notify_thread_id sigev_notify_function
+ 
+ /* auxialiary igt helpers from igt_aux.c */
+ /* generally useful helpers */
+diff --git a/lib/igt_eld.c b/lib/igt_eld.c
+index 3d7fd4d..d51774b 100644
+--- a/lib/igt_eld.c
++++ b/lib/igt_eld.c
+@@ -29,6 +29,7 @@
+ #include <stdint.h>
+ #include <stdio.h>
+ #include <string.h>
++#include <limits.h>
+ 
+ #include "igt_core.h"
+ #include "igt_eld.h"
+diff --git a/lib/igt_halffloat.c b/lib/igt_halffloat.c
+index 08ab05f..7d6a6e6 100644
+--- a/lib/igt_halffloat.c
++++ b/lib/igt_halffloat.c
+@@ -162,7 +162,7 @@ static inline float _half_to_float(uint16_t val)
+ 	return fi.f;
+ }
+ 
+-#if defined(__x86_64__) && !defined(__clang__)
++#if defined(__x86_64__) && !defined(__clang__) && defined(__GLIBC__)
+ #pragma GCC push_options
+ #pragma GCC target("f16c")
+ 
+diff --git a/lib/igt_x86.c b/lib/igt_x86.c
+index 6ac700d..ddf5edd 100644
+--- a/lib/igt_x86.c
++++ b/lib/igt_x86.c
+@@ -190,7 +190,7 @@ char *igt_x86_features_to_string(unsigned features, char *line)
+ }
+ #endif
+ 
+-#if defined(__x86_64__) && !defined(__clang__)
++#if defined(__x86_64__) && !defined(__clang__) && defined(__GLIBC__)
+ #pragma GCC push_options
+ #pragma GCC target("sse4.1")
+ #pragma GCC diagnostic ignored "-Wpointer-arith"
+diff --git a/lib/signal_compat.h b/lib/signal_compat.h
+new file mode 100644
+index 0000000..acae648
+--- /dev/null
++++ b/lib/signal_compat.h
+@@ -0,0 +1,4 @@
++#define SIGEV_SIGNAL    0       /* notify via signal */
++#define SIGEV_NONE      1       /* other notification: meaningless */
++#define SIGEV_THREAD    2       /* deliver via thread creation */
++#define SIGEV_THREAD_ID 4       /* deliver to thread */
+diff --git a/tests/drm_read.c b/tests/drm_read.c
+index cfb1c04..18be922 100644
+--- a/tests/drm_read.c
++++ b/tests/drm_read.c
+@@ -220,7 +220,7 @@ static void test_short_buffer_wakeup(int in, enum pipe pipe)
+ 		pthread_mutex_unlock(&w.mutex);
+ 
+ 		/* Give each thread a chance to sleep in drm_read() */
+-		pthread_yield();
++		sched_yield();
+ 
+ 		/* One event should wake all threads as none consume */
+ 		generate_event(w.fd, pipe);
+diff --git a/tests/kms_hdmi_inject.c b/tests/kms_hdmi_inject.c
+index 8c0d133..f272418 100644
+--- a/tests/kms_hdmi_inject.c
++++ b/tests/kms_hdmi_inject.c
+@@ -25,7 +25,7 @@
+ #include "config.h"
+ 
+ #include <dirent.h>
+-
++#include <limits.h>
+ #include "igt.h"
+ #include "igt_edid.h"
+ #include "igt_eld.h"
+diff --git a/tests/kms_sysfs_edid_timing.c b/tests/kms_sysfs_edid_timing.c
+index 1201388..e75c7e9 100644
+--- a/tests/kms_sysfs_edid_timing.c
++++ b/tests/kms_sysfs_edid_timing.c
+@@ -24,6 +24,7 @@
+ 
+ #include <dirent.h>
+ #include <fcntl.h>
++#include <limits.h>
+ #include <sys/stat.h>
+ 
+ #define THRESHOLD_PER_CONNECTOR	10
+diff --git a/tests/i915/gem_close_race.c b/tests/i915/gem_close_race.c
+index 57e0048..ad5f504 100644
+--- a/tests/i915/gem_close_race.c
++++ b/tests/i915/gem_close_race.c
+@@ -51,7 +51,11 @@
+ static uint32_t devid;
+ static bool has_64bit_relocations;
+ 
+-#define sigev_notify_thread_id _sigev_un._tid
++#ifndef __GLIBC__
++#include "signal_compat.h"
++#endif
++
++#define sigev_notify_thread_id sigev_notify_function
+ 
+ static void selfcopy(int fd, uint32_t handle, int loops)
+ {
+diff --git a/tests/i915/i915_pm_rpm.c b/tests/i915/i915_pm_rpm.c
+index e2c7ba2..08e44b7 100644
+--- a/tests/i915/i915_pm_rpm.c
++++ b/tests/i915/i915_pm_rpm.c
+@@ -36,6 +36,7 @@
+ #include <unistd.h>
+ #include <fcntl.h>
+ #include <dirent.h>
++#include <limits.h>
+ #include <sys/ioctl.h>
+ #include <sys/mman.h>
+ #include <sys/types.h>
+diff --git a/tests/panfrost_submit.c b/tests/panfrost_submit.c
+index 13ce85b..ceb2e6d 100644
+--- a/tests/panfrost_submit.c
++++ b/tests/panfrost_submit.c
+@@ -68,7 +68,7 @@ static void check_error(int fd, struct panfrost_submit *submit)
+ static void check_fb(int fd, struct panfrost_bo *bo)
+ {
+         int gpu_prod_id = igt_panfrost_get_param(fd, DRM_PANFROST_PARAM_GPU_PROD_ID);
+-        __uint32_t *fbo;
++        uint32_t *fbo;
+         int i;
+ 
+         fbo = bo->map;


### PR DESCRIPTION
All patches (except musl-ioctl, which is original) come from Void Linux.